### PR TITLE
Update Cargo.toml add repository

### DIFF
--- a/fluereflow/Cargo.toml
+++ b/fluereflow/Cargo.toml
@@ -7,6 +7,7 @@ description = "Customized flow feature inspired by netflow and cicflowmeter."
 readme = "README.md"
 license = "Apache-2.0"
 keywords = ["netflow", "fluereflow"]
+repository = "https://github.com/SkuldNorniern/fluere"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]


### PR DESCRIPTION
to allow crates.io, rust-digger and others to link to it

